### PR TITLE
Add /health endpoint and integration test (#1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/contextual_ai_ads_platform/controller/HealthController.java
+++ b/src/main/java/com/example/contextual_ai_ads_platform/controller/HealthController.java
@@ -1,0 +1,31 @@
+package com.example.contextual_ai_ads_platform.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * The HealthController provides a simple health check endpoint to verify that
+ * the application is running and responsive.
+ *
+ * @author anuragdeb
+ *
+ */
+
+@RestController
+public class HealthController {
+
+    /**
+     * Returns a simple JSON response indicating the application's health status.
+     *
+     * @return A Map with key "status" and value "UP".
+     */
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        // Returning a Map automatically serializes to JSON.
+        // { "status": "UP" }
+        return Map.of("status", "UP");
+    }
+
+}

--- a/src/test/java/com/example/contextual_ai_ads_platform/controller/HealthControllerIntegrationTest.java
+++ b/src/test/java/com/example/contextual_ai_ads_platform/controller/HealthControllerIntegrationTest.java
@@ -1,0 +1,32 @@
+package com.example.contextual_ai_ads_platform.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test to verify that the /health endpoint is working correctly.
+ *
+ * @author anuragdeb
+ *
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class HealthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpointShouldReturnStatusUp() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+}


### PR DESCRIPTION
This pull request implements the /health endpoint as described in issue #1. The /health endpoint returns a simple JSON object {"status": "UP"} to indicate that the application is running and healthy.

Changes:

- Added HealthController class with a /health GET endpoint.
- Created an integration test (HealthControllerIntegrationTest) to verify the endpoint returns 200 OK and the expected JSON response.
- Verified that the tests pass locally using mvn test.

Testing:

- The integration test confirms the /health endpoint returns the correct response.
- Manually tested by running mvn spring-boot:run and visiting http://localhost:8080/health in a browser.

Issue Reference:

Closes #1

Additional Notes:

This endpoint will serve as a basic check to ensure our application and future services are accessible. Future improvements might include more detailed health checks (e.g., database connectivity, external API calls).