### PR TITLE
Add Ad entity and CRUD functionality (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+# Secrets file
+application-secrets.properties
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/src/main/java/com/example/contextual_ai_ads_platform/controller/AdController.java
+++ b/src/main/java/com/example/contextual_ai_ads_platform/controller/AdController.java
@@ -1,0 +1,55 @@
+package com.example.contextual_ai_ads_platform.controller;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import com.example.contextual_ai_ads_platform.service.AdService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for managing advertisements.
+ * Exposes endpoints for creating, retrieving, updating, and deleting Ads.
+ *
+ * @author anuragdeb
+ *
+ */
+@RestController
+@RequestMapping("/ads")
+public class AdController {
+
+    private final AdService adService;
+
+    public AdController(AdService adService) {
+        this.adService = adService;
+    }
+
+    @PostMapping
+    public Ad createAd(@RequestParam String headline,
+                       @RequestParam String description,
+                       @RequestParam String keywords) {
+        return adService.createAd(headline, description, keywords);
+    }
+
+    @GetMapping
+    public List<Ad> getAllAds() {
+        return adService.getAllAds();
+    }
+
+    @GetMapping("/{id}")
+    public Ad getAdById(@PathVariable Long id) {
+        return adService.getAdById(id);
+    }
+
+    @PutMapping("/{id}")
+    public Ad updateAd(@PathVariable Long id,
+                       @RequestParam String headline,
+                       @RequestParam String description,
+                       @RequestParam String keywords) {
+        return adService.updateAd(id, headline, description, keywords);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteAd(@PathVariable Long id) {
+        adService.deleteAd(id);
+    }
+}

--- a/src/main/java/com/example/contextual_ai_ads_platform/entity/Ad.java
+++ b/src/main/java/com/example/contextual_ai_ads_platform/entity/Ad.java
@@ -1,0 +1,69 @@
+package com.example.contextual_ai_ads_platform.entity;
+
+import jakarta.persistence.*;
+
+/**
+ * Represents an advertisement entity in the database.
+ * This entity is used to store and manage details about advertisements,
+ * including their headline, description, and associated keywords.
+ *
+ * @author anuragdeb
+ *
+ */
+
+@Entity
+public class Ad {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String headline;
+
+    private String description;
+
+    private String keywords;
+
+    public Ad() {}
+
+    public Ad(String headline, String description, String keywords) {
+        this.headline = headline;
+        this.description = description;
+        this.keywords = keywords;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getHeadline() {
+        return headline;
+    }
+
+    public void setHeadline(String headline) {
+        this.headline = headline;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getKeywords() {
+        return keywords;
+    }
+
+    public void setKeywords(String keywords) {
+        this.keywords = keywords;
+    }
+
+}

--- a/src/main/java/com/example/contextual_ai_ads_platform/repository/AdRepository.java
+++ b/src/main/java/com/example/contextual_ai_ads_platform/repository/AdRepository.java
@@ -1,0 +1,15 @@
+package com.example.contextual_ai_ads_platform.repository;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for managing Ad entities in the database.
+ *
+ * @author anuragdeb
+ *
+ */
+@Repository
+public interface AdRepository extends JpaRepository<Ad, Long> {
+}

--- a/src/main/java/com/example/contextual_ai_ads_platform/service/AdService.java
+++ b/src/main/java/com/example/contextual_ai_ads_platform/service/AdService.java
@@ -1,0 +1,48 @@
+package com.example.contextual_ai_ads_platform.service;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import com.example.contextual_ai_ads_platform.repository.AdRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service class for business logic and management of Ad entities.
+ *
+ * @author anuragdeb
+ *
+ */
+@Service
+public class AdService {
+
+    private final AdRepository adRepository;
+
+    public AdService(AdRepository adRepository) {
+        this.adRepository = adRepository;
+    }
+
+    public Ad createAd(String headline, String description, String keywords) {
+        Ad ad = new Ad(headline, description, keywords);
+        return adRepository.save(ad);
+    }
+
+    public List<Ad> getAllAds() {
+        return adRepository.findAll();
+    }
+
+    public Ad getAdById(Long id) {
+        return adRepository.findById(id).orElseThrow(() -> new RuntimeException("Ad not found"));
+    }
+
+    public Ad updateAd(Long id, String headline, String description, String keywords) {
+        Ad ad = getAdById(id);
+        ad.setHeadline(headline);
+        ad.setDescription(description);
+        ad.setKeywords(keywords);
+        return adRepository.save(ad);
+    }
+
+    public void deleteAd(Long id) {
+        adRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=contextual-ai-ads-platform
+
+# application.properties
+spring.config.import=application-secrets.properties
+
+# Database connection
+spring.datasource.url=jdbc:postgresql://localhost:5432/contextual_ads
+
+# JPA configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/example/contextual_ai_ads_platform/controller/AdControllerTest.java
+++ b/src/test/java/com/example/contextual_ai_ads_platform/controller/AdControllerTest.java
@@ -1,0 +1,71 @@
+package com.example.contextual_ai_ads_platform.controller;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import com.example.contextual_ai_ads_platform.service.AdService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for AdController to verify REST API endpoints and request handling.
+ *
+ * @author anuragdeb
+ */
+@WebMvcTest(AdController.class)
+public class AdControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdService adService;
+
+    @Test
+    void testGetAllAds() throws Exception {
+        // Arrange
+        Ad ad = new Ad("Big Sale", "50% off on all items", "sale,discount");
+        when(adService.getAllAds()).thenReturn(List.of(ad));
+
+        // Act & Assert
+        mockMvc.perform(get("/ads"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].headline").value("Big Sale"));
+    }
+
+    @Test
+    void testCreateAd() throws Exception {
+        // Arrange
+        Ad ad = new Ad("Big Sale", "50% off on all items", "sale,discount");
+        when(adService.createAd("Big Sale", "50% off on all items", "sale,discount")).thenReturn(ad);
+
+        // Act & Assert
+        mockMvc.perform(post("/ads")
+                        .param("headline", "Big Sale")
+                        .param("description", "50% off on all items")
+                        .param("keywords", "sale,discount")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.headline").value("Big Sale"));
+    }
+
+    @Test
+    void testGetAdById() throws Exception {
+        // Arrange
+        Ad ad = new Ad("Limited Offer", "Offer ends today", "offer,discount");
+        when(adService.getAdById(1L)).thenReturn(ad);
+
+        // Act & Assert
+        mockMvc.perform(get("/ads/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.headline").value("Limited Offer"));
+    }
+}

--- a/src/test/java/com/example/contextual_ai_ads_platform/repository/AdRepositoryTest.java
+++ b/src/test/java/com/example/contextual_ai_ads_platform/repository/AdRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.example.contextual_ai_ads_platform.repository;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for AdRepository to verify database operations.
+ *
+ * @author anuragdeb
+ */
+@DataJpaTest
+public class AdRepositoryTest {
+
+    @Autowired
+    private AdRepository adRepository;
+
+    @Test
+    void testSaveAndFindAd() {
+        // Arrange
+        Ad ad = new Ad("Big Sale", "50% off on all items", "sale,discount");
+
+        // Act
+        Ad savedAd = adRepository.save(ad);
+
+        // Assert
+        assertThat(savedAd).isNotNull();
+        assertThat(savedAd.getId()).isNotNull();
+        assertThat(savedAd.getHeadline()).isEqualTo("Big Sale");
+
+        // Retrieve all ads
+        List<Ad> ads = adRepository.findAll();
+        assertThat(ads).hasSize(1);
+    }
+
+    @Test
+    void testDeleteAd() {
+        // Arrange
+        Ad ad = new Ad("Limited Offer", "Offer ends today", "offer,discount");
+        Ad savedAd = adRepository.save(ad);
+
+        // Act
+        adRepository.deleteById(savedAd.getId());
+
+        // Assert
+        assertThat(adRepository.findById(savedAd.getId())).isEmpty();
+    }
+}

--- a/src/test/java/com/example/contextual_ai_ads_platform/service/AdServiceTest.java
+++ b/src/test/java/com/example/contextual_ai_ads_platform/service/AdServiceTest.java
@@ -1,0 +1,75 @@
+package com.example.contextual_ai_ads_platform.service;
+
+import com.example.contextual_ai_ads_platform.entity.Ad;
+import com.example.contextual_ai_ads_platform.repository.AdRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for AdService to verify business logic and interactions with AdRepository.
+ *
+ * @author anuragdeb
+ */
+public class AdServiceTest {
+
+    @Mock
+    private AdRepository adRepository;
+
+    @InjectMocks
+    private AdService adService;
+
+    public AdServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateAd() {
+        // Arrange
+        Ad ad = new Ad("Big Sale", "50% off on all items", "sale,discount");
+        when(adRepository.save(any(Ad.class))).thenReturn(ad);
+
+        // Act
+        Ad createdAd = adService.createAd("Big Sale", "50% off on all items", "sale,discount");
+
+        // Assert
+        assertThat(createdAd).isNotNull();
+        assertThat(createdAd.getHeadline()).isEqualTo("Big Sale");
+        verify(adRepository, times(1)).save(any(Ad.class));
+    }
+
+    @Test
+    void testGetAdById() {
+        // Arrange
+        Ad ad = new Ad("Limited Offer", "Offer ends today", "offer,discount");
+        ad.setId(1L);
+        when(adRepository.findById(1L)).thenReturn(Optional.of(ad));
+
+        // Act
+        Ad retrievedAd = adService.getAdById(1L);
+
+        // Assert
+        assertThat(retrievedAd).isNotNull();
+        assertThat(retrievedAd.getHeadline()).isEqualTo("Limited Offer");
+        verify(adRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void testDeleteAd() {
+        // Arrange
+        Long adId = 1L;
+        doNothing().when(adRepository).deleteById(adId);
+
+        // Act
+        adService.deleteAd(adId);
+
+        // Assert
+        verify(adRepository, times(1)).deleteById(adId);
+    }
+}


### PR DESCRIPTION
This pull request implements the necessary components for managing advertisements in the application, including CRUD operations and unit tests. Key changes include:

AdController:
- Exposes REST endpoints for creating, retrieving, updating, and deleting ads.
- Supports integration with the AdService layer.

AdService:
- Handles business logic for ad management.
- Interacts with AdRepository for data persistence.

AdRepository:
- Uses Spring Data JPA to manage database operations for the Ad entity.

Ad Entity:
- Represents the advertisement structure in the database.

Unit Tests:
- Added unit tests for AdController using MockMvc.
- Mocked AdService to ensure isolation of the controller layer.

Testing:
Verified endpoints:
- GET /ads: Fetch all ads.
- GET /ads/{id}: Fetch a specific ad by ID.
- POST /ads: Create a new ad.
- PUT /ads/{id}: Update an ad.
- DELETE /ads/{id}: Delete an ad.
All tests are passing, ensuring functionality and code reliability.

Related Issue: Closes #3.

